### PR TITLE
Updating documentation

### DIFF
--- a/lib/curate/indexer.rb
+++ b/lib/curate/indexer.rb
@@ -65,7 +65,6 @@ module Curate
     # @see Curate::Indexer::Railtie
     def self.configure(&block)
       @configuration_block = block
-      configure!
       # The Rails load sequence means that some of the configured Targets may
       # not be loaded; As such I am not calling configure! instead relying on
       # Curate::Indexer::Railtie to handle the configure! call

--- a/lib/curate/indexer.rb
+++ b/lib/curate/indexer.rb
@@ -38,6 +38,8 @@ module Curate
       true
     end
 
+    # @api public
+    #
     # Contains the Curate::Indexer configuration information that is referenceable from wit
     # @see Curate::Indexer::Configuration
     def self.configuration
@@ -45,13 +47,22 @@ module Curate
     end
 
     # @api public
+    #
+    # Exposes the data adapter to use for the reindexing process.
+    #
+    # @see Curate::Indexer::Adapters::AbstractAdapter
+    # @return Object that implementes the Curate::Indexer::Adapters::AbstractAdapter method interface
     def self.adapter
       configuration.adapter
     end
 
     # @api public
+    #
+    # Capture the configuration information
+    #
     # @see Curate::Indexer::Configuration
     # @see .configuration
+    # @see Curate::Indexer::Railtie
     def self.configure(&block)
       @configuration_block = block
       configure!
@@ -61,7 +72,7 @@ module Curate
       configure! unless defined?(Rails)
     end
 
-    # @api public
+    # @api private
     def self.configure!
       return false unless @configuration_block.respond_to?(:call)
       @configuration_block.call(configuration)

--- a/lib/curate/indexer.rb
+++ b/lib/curate/indexer.rb
@@ -18,7 +18,7 @@ module Curate
     # @return [Boolean] - It was successful
     # @raise Curate::Exceptions::CycleDetectionError - A potential cycle was detected
     def self.reindex_relationships(pid, time_to_live = DEFAULT_TIME_TO_LIVE)
-      RelationshipReindexer.call(pid: pid, time_to_live: time_to_live, adapter: configuration.adapter)
+      RelationshipReindexer.call(pid: pid, time_to_live: time_to_live, adapter: adapter)
       true
     end
 
@@ -34,7 +34,10 @@ module Curate
     # @return [Boolean] - It was successful
     # @raise Curate::Exceptions::CycleDetectionError - A potential cycle was detected
     def self.reindex_all!(time_to_live = DEFAULT_TIME_TO_LIVE)
-      RepositoryReindexer.call(time_to_live: time_to_live, pid_reindexer: method(:reindex_relationships), adapter: configuration.adapter)
+      # While the RepositoryReindexer is responsible for reindexing everything, I
+      # want to inject the lambda that will reindex a single item.
+      pid_reindexer = method(:reindex_relationships)
+      RepositoryReindexer.call(time_to_live: time_to_live, pid_reindexer: pid_reindexer, adapter: adapter)
       true
     end
 

--- a/lib/curate/indexer/configuration.rb
+++ b/lib/curate/indexer/configuration.rb
@@ -11,8 +11,11 @@ module Curate
 
       private
 
+      IN_MEMORY_ADAPTER_WARNING_MESSAGE =
+        "WARNING: You are using the default Curate::Indexer::Adapters::InMemoryAdapter for the Curate::Indexer.adapter.".freeze
+
       def default_adapter
-        $stdout.puts "WARNING: You are using the default Curate::Indexer::Adapters::InMemoryAdapter for the Curate::Indexer.adapter."
+        $stdout.puts IN_MEMORY_ADAPTER_WARNING_MESSAGE unless defined?(SUPPRESS_MEMORY_ADAPTER_WARNING)
         require 'curate/indexer/adapters/in_memory_adapter'
         Adapters::InMemoryAdapter
       end

--- a/lib/curate/indexer/railtie.rb
+++ b/lib/curate/indexer/railtie.rb
@@ -5,7 +5,7 @@ module Curate
     # Connect into the boot sequence of a Rails application
     class Railtie < Rails::Railtie
       config.to_prepare do
-        Curate::Indexer.send(:configure!)
+        Curate::Indexer.configure!
       end
     end
   end

--- a/spec/lib/curate/indexer_spec.rb
+++ b/spec/lib/curate/indexer_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'curate/indexer'
+
+describe Curate::Indexer do
+  describe '.configure' do
+    before do
+      Object.send(:remove_const, :Rails) if defined?(Rails)
+    end
+    describe 'without Rails defined' do
+      it 'will call the configuration block' do
+        expect { |b| described_class.configure(&b) }.to yield_control
+      end
+    end
+
+    describe 'with Rails defined' do
+      before do
+        module Rails
+        end
+      end
+      after do
+        Object.send(:remove_const, :Rails)
+      end
+      it 'will not call the configuration block immediately but instead rely on the Curate::Indexer::Railtie' do
+        expect { |b| described_class.configure(&b) }.to_not yield_control
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+SUPPRESS_MEMORY_ADAPTER_WARNING = true
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'coverage_helper'
 require 'curate/indexer'


### PR DESCRIPTION
## Updating documentation for gem

@478a58dbe689e239144f2dae83edc6721d4b4b7d


## Marking method as api private but still public

@ec91b9ba25d580cdfa3ab378fedb01b9e886606f

Just tidying up the interplay

## Updating variable definition for clarity

@48c4e458360803dbc1ad2e15f0c9e82a978a23dc


## Adding spec for configure with(out) Rails

@90213dcb8f21c34e87ae49cefa1eb9380ec7604a

This was not being properly tested. It also triggered the generation
of warning messages; So those are now suppressed.
